### PR TITLE
feat: Implement data ingestion system for 17Lands

### DIFF
--- a/README.md
+++ b/README.md
@@ -818,6 +818,22 @@ python3 manage_data.py --update-scryfall
 
 # Show status
 python3 manage_data.py --status
+
+### Downloading 17Lands Data
+To download raw data from 17Lands, use the `download` command. This data is saved in a versioned directory structure to facilitate analysis of specific sets and time periods. You can specify the data type to download using the `--data-type` argument.
+
+```bash
+# Download replay data for a single set
+python3 data_management.py download --set-codes MKM --data-type replay_data
+
+# Download draft data for multiple sets
+python3 data_management.py download --set-codes MKM LCI --data-type draft_data
+
+# Download game data for a single set
+python3 data_management.py download --set-codes MKM --data-type game_data
+```
+
+**Data Versioning:** The downloaded data is organized in the `data/17lands` directory, with subdirectories for each set and the date of download (e.g., `data/17lands/MKM/2025-11-06`). For more advanced data versioning and management, consider using tools like [DVC](https://dvc.org/) or [Git LFS](https://git-lfs.github.com/).
 ```
 
 ### Testing Components

--- a/data_management.py
+++ b/data_management.py
@@ -1141,3 +1141,41 @@ def check_and_update_card_database() -> bool:
         logging.error(f"Failed to verify card database: {e}")
         return False
 
+if __name__ == "__main__":
+    from constants import ALL_SETS, CURRENT_STANDARD
+    from tools.download_17lands_data import download_17lands_data
+
+    logging.basicConfig(level=logging.INFO)
+
+    parser = argparse.ArgumentParser(description="Manage MTGA Advisor data.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # Status command
+    parser_status = subparsers.add_parser("status", help="Show data status")
+
+    # 17lands command
+    parser_17lands = subparsers.add_parser("update-17lands", help="Update 17lands data")
+    parser_17lands.add_argument("--all-sets", action="store_true", help="Download all sets, not just current standard")
+    parser_17lands.add_argument("--max-age", type=int, default=30, help="Max age of data in days before re-downloading")
+
+    # Scryfall command
+    parser_scryfall = subparsers.add_parser("update-scryfall", help="Update Scryfall cache")
+
+    # Download command
+    parser_download = subparsers.add_parser("download", help="Download 17lands data")
+    parser_download.add_argument("--set-codes", type=str, nargs='+', required=True, help="One or more MTG set codes (e.g., 'MKM' 'LCI')")
+    parser_download.add_argument("--draft-type", type=str, default="PremierDraft", help="Draft type (e.g., 'PremierDraft')")
+    parser_download.add_argument("--data-type", type=str, default="replay_data", help="Data type to download (e.g., 'draft_data', 'game_data', 'replay_data')")
+    parser_download.add_argument("--output-dir", type=Path, default=Path("data/17lands"), help="Directory to save the data")
+
+    args = parser.parse_args()
+
+    if args.command == "status":
+        show_status()
+    elif args.command == "update-17lands":
+        update_17lands_data(args.all_sets, args.max_age)
+    elif args.command == "update-scryfall":
+        update_scryfall_data()
+    elif args.command == "download":
+        for set_code in args.set_codes:
+            download_17lands_data(set_code, args.draft_type, args.data_type, args.output_dir)

--- a/tools/download_17lands_data.py
+++ b/tools/download_17lands_data.py
@@ -1,0 +1,76 @@
+import logging
+import requests
+import gzip
+import shutil
+import time
+from pathlib import Path
+from datetime import datetime
+
+# Configure logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+def download_17lands_data(set_code: str, draft_type: str, data_type: str, output_dir: Path, retries: int = 3, backoff_factor: float = 0.5):
+    """
+    Downloads and decompresses 17Lands data for a specific set, draft type, and data type.
+
+    Args:
+        set_code (str): The MTG set code (e.g., 'MKM').
+        draft_type (str): The draft type (e.g., 'PremierDraft').
+        data_type (str): The data type to download (e.g., 'draft_data', 'game_data', 'replay_data').
+        output_dir (Path): The directory to save the downloaded file.
+        retries (int): The number of times to retry the download on failure.
+        backoff_factor (float): The factor to use for exponential backoff between retries.
+    """
+    # Validate data_type
+    valid_data_types = ['draft_data', 'game_data', 'replay_data']
+    if data_type not in valid_data_types:
+        logging.error(f"Invalid data_type: {data_type}. Must be one of {valid_data_types}")
+        return
+
+    # Create a versioned directory structure
+    date_str = datetime.now().strftime('%Y-%m-%d')
+    versioned_dir = output_dir / set_code / date_str
+    versioned_dir.mkdir(parents=True, exist_ok=True)
+
+    url = f"https://17lands-public.s3.amazonaws.com/analysis_data/{data_type}/{set_code}_{draft_type}.csv.gz"
+    gz_filename = f"{set_code}_{draft_type}.csv.gz"
+    csv_filename = f"{set_code}_{draft_type}.csv"
+
+    gz_filepath = versioned_dir / gz_filename
+    csv_filepath = versioned_dir / csv_filename
+
+    logging.info(f"Downloading data for {set_code} ({draft_type}, {data_type}) from {url}")
+
+    for i in range(retries):
+        try:
+            with requests.get(url, stream=True) as r:
+                r.raise_for_status()
+                with open(gz_filepath, 'wb') as f:
+                    for chunk in r.iter_content(chunk_size=8192):
+                        f.write(chunk)
+
+            logging.info(f"Successfully downloaded {gz_filepath}")
+
+            logging.info(f"Decompressing {gz_filepath} to {csv_filepath}")
+            with gzip.open(gz_filepath, 'rb') as f_in:
+                with open(csv_filepath, 'wb') as f_out:
+                    shutil.copyfileobj(f_in, f_out)
+
+            logging.info(f"Successfully decompressed to {csv_filepath}")
+
+            # Clean up the compressed file
+            gz_filepath.unlink()
+            logging.info(f"Removed compressed file: {gz_filepath}")
+            return
+
+        except requests.exceptions.RequestException as e:
+            logging.warning(f"Attempt {i + 1} of {retries} failed: {e}")
+            if i < retries - 1:
+                sleep_time = backoff_factor * (2 ** i)
+                logging.info(f"Retrying in {sleep_time} seconds...")
+                time.sleep(sleep_time)
+            else:
+                logging.error(f"Failed to download data for {set_code} ({draft_type}, {data_type}) after {retries} attempts.")
+        except Exception as e:
+            logging.error(f"An unexpected error occurred: {e}")
+            break


### PR DESCRIPTION
This commit introduces a new data ingestion system for downloading public datasets from 17Lands.

Key features:
- A new `download` command has been added to `data_management.py` to allow users to download `draft_data`, `game_data`, and `replay_data`.
- The download logic includes a retry mechanism with exponential backoff to handle network errors gracefully.
- A basic data versioning system has been implemented by organizing downloaded data into a date-stamped directory structure.
- The `README.md` has been updated to document the new functionality.