### PR TITLE
Fix replay_data download URL in tools/download_17lands_data.py

### DIFF
--- a/tools/download_17lands_data.py
+++ b/tools/download_17lands_data.py
@@ -57,7 +57,7 @@ def download_17lands_data(set_code: str, data_type: str, output_dir: Path, retri
 
     # Construct the URL based on the data type
     if data_type == "replay_data":
-        url = f"https://17lands-public.s3.amazonaws.com/replay_data/replay_data_public.{set_code}.PremierDraft.csv.gz"
+        url = f"https://17lands-public.s3.amazonaws.com/analysis_data/replay_data/replay_data_public.{set_code}.PremierDraft.csv.gz"
     else:
         url = f"https://17lands-public.s3.amazonaws.com/analysis_data/{data_type}/{data_type}_public.{set_code}.PremierDraft.csv.gz"
 


### PR DESCRIPTION
The script was failing to download replay_data files with a '403 Forbidden' error. This was because the URL was incorrect.

This commit updates the URL to the correct format, which is nested under the 'analysis_data' path in the S3 bucket.